### PR TITLE
Filter zoom URLs to only close tabs with /s/ or /j/ paths

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,11 @@
     {
       "run_at": "document_start",
       "matches": [
-        "*://*.zoom.us/*",
+        "*://*.zoom.us/j/*",
+        "*://*.zoom.us/s/*",
+        "*://*.zoom.us/wc/*",
+        "*://*.zoom.us/my/*",
+        "*://*.zoom.us/w/*",
         "*://app.asana.com/-/desktop_app_link*",
         "*://*.slack.com/*"
       ],


### PR DESCRIPTION
Updates the extension to only auto-close zoom tabs that are actually join links. This prevents the extension from closing other zoom.us pages like settings, profile, or download pages.